### PR TITLE
Allow upload of zip files to hoardbooru

### DIFF
--- a/client/build.js
+++ b/client/build.js
@@ -243,6 +243,9 @@ function bundleConfig() {
 
 function bundleBinaryAssets() {
     fs.copyFileSync('./img/favicon.png', './public/img/favicon.png');
+
+    fs.copyFileSync('./img/doc_zip.svg', './public/img/doc_zip.svg');
+
     console.info('Copied images');
 
     fs.copyFileSync('./fonts/open_sans.woff2', './public/fonts/open_sans.woff2')

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -27,6 +27,18 @@
             'Your browser doesn\'t support HTML5 videos.')
         %>
 
+    <% } else if (ctx.post.type === 'zip') { %>
+
+        <% if (ctx.post.hasCustomThumbnail === true) { %>
+            
+            <img class='resize-listener' alt='' src='<%- ctx.post.thumbnailUrl %>'/>
+
+        <% } else { %>
+
+            <img class='resize-listener' alt='' src='/img/doc_zip.svg'/>
+
+        <% } %>
+
     <% } else { console.log(new Error('Unknown post type')); } %>
 
     <div class='post-overlay resize-listener'>

--- a/client/html/post_merge_side.tpl
+++ b/client/html/post_merge_side.tpl
@@ -44,6 +44,7 @@
                     'video/mp4': 'MPEG-4',
                     'video/quicktime': 'MOV',
                     'application/x-shockwave-flash': 'SWF',
+                    'application/zip': 'ZIP'
                 }[ctx.post.mimeType] +
                 ' (' +
                 (ctx.post.canvasWidth ?

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -17,6 +17,7 @@
                     'video/mp4': 'MPEG-4',
                     'video/quicktime': 'MOV',
                     'application/x-shockwave-flash': 'SWF',
+                    'application/zip': 'ZIP'
                 }[ctx.post.mimeType] %><!--
             --></a>
             (<%- ctx.post.canvasWidth %>x<%- ctx.post.canvasHeight %>)

--- a/client/html/posts_page.tpl
+++ b/client/html/posts_page.tpl
@@ -6,10 +6,18 @@
                     <a class='thumbnail-wrapper <%= post.tags.length > 0 ? "tags" : "no-tags" %>'
                             title='@<%- post.id %> (<%- post.type %>)&#10;&#10;Tags: <%- post.tags.map(tag => '#' + tag.names[0]).join(' ') || 'none' %>'
                             href='<%= ctx.canViewPosts ? ctx.getPostUrl(post.id, ctx.parameters) : '' %>'>
-                        <%= ctx.makeThumbnail(post.thumbnailUrl) %>
+
+                        <% if (post.type == 'zip' && post.hasCustomThumbnail !== true) { %>
+                            <%= ctx.makeThumbnail("img/doc_zip.svg") %>
+                        <% } else { %>
+                            <%= ctx.makeThumbnail(post.thumbnailUrl) %>
+                        <% } %>
+                          
                         <span class='type' data-type='<%- post.type %>'>
                             <% if (post.type == 'video' || post.type == 'flash' || post.type == 'animation') { %>
                                 <span class='icon'><i class='fa fa-film'></i></span>
+                            <% } else if (post.type == 'zip') { %>
+                                <span class='icon'><i class='fa fa-file-archive-o'></i></span>
                             <% } else { %>
                                 <%- post.type %>
                             <% } %>

--- a/client/img/doc_zip.svg
+++ b/client/img/doc_zip.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+     y="0px" viewBox="0 0 150 150" style="enable-background:new 0 0 150 150" xml:space="preserve">
+    <style type="text/css">
+        .doc {
+            stroke: #000;
+            stroke-width: 5px;
+            stroke-linejoin: round;
+            fill: none;
+        }
+        .label {
+            fill: #000;
+        }
+        .text {
+            fill: #FFF;
+        }
+        .bg {
+            fill: transparent;
+        }
+    </style>
+    <defs>
+        <mask id="labelText">
+            <rect x="0" y="0" width="150" height="150" fill="white"/>
+            <text x="60" y="90" textLength="60" font-size="30" fill="black">ZIP</text>
+        </mask>
+    </defs>
+    <g>
+        <rect class="bg" x="0" y="0" width="150" height="150" />
+        <path class="doc" d="M90 25 L40 25 L40 125 L110 125 L110 45 L90 45 L90 25 L110 45" mask="url(#labelText)" />
+        <rect class="label" x="50" y="60" width="80" height="40" rx="5" ry="5" mask="url(#labelText)"/>
+    </g>
+</svg>

--- a/client/js/controllers/post_list_controller.js
+++ b/client/js/controllers/post_list_controller.js
@@ -14,6 +14,7 @@ const EmptyView = require("../views/empty_view.js");
 const fields = [
     "id",
     "thumbnailUrl",
+    "hasCustomThumbnail",
     "type",
     "safety",
     "score",

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -12,6 +12,7 @@ function _mimeTypeToPostType(mimeType) {
     return (
         {
             "application/x-shockwave-flash": "flash",
+            "application/zip": "zip",
             "image/gif": "image",
             "image/jpeg": "image",
             "image/png": "image",
@@ -112,6 +113,7 @@ class Url extends Uploadable {
     get mimeType() {
         let mime = {
             swf: "application/x-shockwave-flash",
+            zip: "application/zip",
             jpg: "image/jpeg",
             png: "image/png",
             gif: "image/gif",
@@ -165,7 +167,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .zip",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -108,3 +108,9 @@ def is_heif(mime_type: str) -> bool:
         "image/heic",
         "image/avif",
     )
+
+
+def is_visual(mime_type: str) -> bool:
+    return mime_type.lower() not in (
+        "application/zip",
+    )

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -42,12 +42,16 @@ def get_mime_type(content: bytes) -> str:
     if content[4:12] == b"ftypqt  ":
         return "video/quicktime"
 
+    if content[0:4] == b"PK\x03\x04":
+        return "application/zip"
+
     return "application/octet-stream"
 
 
 def get_extension(mime_type: str) -> Optional[str]:
     extension_map = {
         "application/x-shockwave-flash": "swf",
+        "application/zip": "zip",
         "image/gif": "gif",
         "image/jpeg": "jpg",
         "image/png": "png",

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -649,28 +649,31 @@ def update_post_content(post: model.Post, content: Optional[bytes]) -> None:
         post.signature = generate_post_signature(post, content)
 
     post.file_size = len(content)
+    if mime.is_visual(post.mime_type):
+        post.canvas_width, post.canvas_height = _try_get_dimensions(content)
+    setattr(post, "__content", content)
+
+
+def _try_get_dimensions(content: Optional[bytes]) -> Tuple[Optional[int], Optional[int]]:
+    # Try and load as image
     try:
         image = images.Image(content)
-        post.canvas_width = image.width
-        post.canvas_height = image.height
     except errors.ProcessingError as ex:
         logger.exception(ex)
         if not config.config["allow_broken_uploads"]:
             raise InvalidPostContentError("Unable to process image metadata")
         else:
-            post.canvas_width = None
-            post.canvas_height = None
-    if (post.canvas_width is not None and post.canvas_width <= 0) or (
-        post.canvas_height is not None and post.canvas_height <= 0
+            return None, None
+    # If canvas size is negative, then handle that
+    if (image.width is not None and image.width <= 0) or (
+        image.height is not None and image.height <= 0
     ):
         if not config.config["allow_broken_uploads"]:
             raise InvalidPostContentError(
                 "Invalid image dimensions returned during processing"
             )
         else:
-            post.canvas_width = None
-            post.canvas_height = None
-    setattr(post, "__content", content)
+            return None, None
 
 
 def update_post_thumbnail(

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -674,6 +674,7 @@ def _try_get_dimensions(content: Optional[bytes]) -> Tuple[Optional[int], Option
             )
         else:
             return None, None
+    return image.width, image.height
 
 
 def update_post_thumbnail(

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -89,6 +89,7 @@ TYPE_MAP = {
     model.Post.TYPE_ANIMATION: "animation",
     model.Post.TYPE_VIDEO: "video",
     model.Post.TYPE_FLASH: "flash",
+    model.Post.TYPE_ZIP: "zip",
 }
 
 FLAG_MAP = {
@@ -621,6 +622,8 @@ def update_post_content(post: model.Post, content: Optional[bytes]) -> None:
             post.type = model.Post.TYPE_IMAGE
     elif mime.is_video(post.mime_type):
         post.type = model.Post.TYPE_VIDEO
+    elif post.mime_type == "application/zip":
+        post.type = model.Post.TYPE_ZIP
     else:
         raise InvalidPostContentError(
             "Unhandled file type: %r" % post.mime_type

--- a/server/szurubooru/model/post.py
+++ b/server/szurubooru/model/post.py
@@ -194,6 +194,7 @@ class Post(Base):
     TYPE_ANIMATION = "animation"
     TYPE_VIDEO = "video"
     TYPE_FLASH = "flash"
+    TYPE_ZIP = "zip"
 
     FLAG_LOOP = "loop"
     FLAG_SOUND = "sound"

--- a/server/szurubooru/search/configs/post_search_config.py
+++ b/server/szurubooru/search/configs/post_search_config.py
@@ -25,6 +25,7 @@ def _type_transformer(value: str) -> str:
         "webm": model.Post.TYPE_VIDEO,
         "flash": model.Post.TYPE_FLASH,
         "swf": model.Post.TYPE_FLASH,
+        "zip": model.Post.TYPE_ZIP,
     }
     return search_util.enum_transformer(available_values, value)
 


### PR DESCRIPTION
This should be enough to add the concept of zip files to hoardbooru. There's a couple file edits here I'm not sure I understand, but, yeah.

Much is copied, and iterated, from sticknuder's nodebooru commit here:
https://github.com/sticknuder/nodebooru/commit/d6fa0aa44835c4b581de58c6ee0a7195a63f43cc

But a few things are modified:
- Only 1 file type, not multiple
- archive icon, rather than cube
- Not using the filename to get the mime type
- Skipping calculation of image resolution
- There's some bits in there about anonymous upload I think, I've excluded those