### PR TITLE
Adding support for psd upload and image/vnd.adobe.photoshop mime type

### DIFF
--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -1,7 +1,11 @@
 <div class='post-content post-type-<%- ctx.post.type %>'>
     <% if (['image', 'animation'].includes(ctx.post.type)) { %>
 
-        <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
+        <% if (ctx.post.mimeType === 'image/vnd.adobe.photoshop') { %>
+            <img class='resize-listener' alt='' src='<%- ctx.post.thumbnailUrl %>'/>
+        <% } else { %>
+            <img class='resize-listener' alt='' src='<%- ctx.post.contentUrl %>'/>
+        <% } %>
 
     <% } else if (ctx.post.type === 'flash') { %>
 

--- a/client/html/post_merge_side.tpl
+++ b/client/html/post_merge_side.tpl
@@ -40,6 +40,7 @@
                     'image/avif': 'AVIF',
                     'image/heif': 'HEIF',
                     'image/heic': 'HEIC',
+                    'image/vnd.adobe.photoshop': 'PSD',
                     'video/webm': 'WEBM',
                     'video/mp4': 'MPEG-4',
                     'video/quicktime': 'MOV',

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -13,6 +13,7 @@
                     'image/avif': 'AVIF',
                     'image/heif': 'HEIF',
                     'image/heic': 'HEIC',
+                    'image/vnd.adobe.photoshop': 'PSD',
                     'video/webm': 'WEBM',
                     'video/mp4': 'MPEG-4',
                     'video/quicktime': 'MOV',

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -22,6 +22,7 @@ function _mimeTypeToPostType(mimeType) {
             "image/avif": "image",
             "image/heif": "image",
             "image/heic": "image",
+            "image/vnd.adobe.photoshop": "image",
             "video/mp4": "video",
             "video/webm": "video",
             "video/quicktime": "video",
@@ -124,6 +125,7 @@ class Url extends Uploadable {
             avif: "image/avif",
             heif: "image/heif",
             heic: "image/heic",
+            psd: "image/vnd.adobe.photoshop",
             mp4: "video/mp4",
             mov: "video/quicktime",
             webm: "video/webm",
@@ -169,7 +171,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .zip, .pdf",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd, .zip, .pdf",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -48,6 +48,9 @@ def get_mime_type(content: bytes) -> str:
     if content[0:4] == b"\x25\x50\x44\x46":
         return "application/pdf"
 
+    if content[0:4] == b"\x38\x42\x50\x53":
+        return "image/vnd.adobe.photoshop"
+
     return "application/octet-stream"
 
 
@@ -64,6 +67,7 @@ def get_extension(mime_type: str) -> Optional[str]:
         "image/avif": "avif",
         "image/heif": "heif",
         "image/heic": "heic",
+        "image/vnd.adobe.photoshop": "psd",
         "video/mp4": "mp4",
         "video/quicktime": "mov",
         "video/webm": "webm",
@@ -95,6 +99,7 @@ def is_image(mime_type: str) -> bool:
         "image/avif",
         "image/heif",
         "image/heic",
+        "image/vnd.adobe.photoshop",
     )
 
 

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -549,6 +549,13 @@ def purge_post_signature(post: model.Post) -> None:
 
 
 def generate_post_signature(post: model.Post, content: bytes) -> None:
+    # Photoshop PSD files can't get parsed by pillow, so convert to png
+    if post.mime_type == "image/vnd.adobe.photoshop":
+        image = images.Image(content)
+        image.resize_fill(image.width, image.height)
+        content = image.content
+
+    # Generate hash signatures
     try:
         unpacked_signature = image_hash.generate_signature(content)
         packed_signature = image_hash.pack_signature(unpacked_signature)


### PR DESCRIPTION
Using the image.vnd.adobe.photoshop mime type

Didn't have to add a new post type with this one (like I did in #1 and #2), so it was a bit easier.
I did have to write some hack around hashing the image though. Have to convert from psd to png first, which ffmpeg can do (though Pillow cannot)

Have tested on local instance, seems to work