### PR TITLE
Add support for plaintext .txt files. Provided they decode as utf-8

### DIFF
--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -48,7 +48,15 @@
         <% if (ctx.post.mimeType === 'application/pdf') { %>
 
             <object class='resize-listener' data='<%- ctx.post.contentUrl %>'>
+            <a href='<%- ctx.post.contentUrl %>'>No pdf embed support?</a>
             </object>
+
+        <% } else if (ctx.post.mimeType === 'text/plain') { %>
+
+            <object class='resize-listener' data='<%- ctx.post.contentUrl %>' type="text/plain">
+            <a href='<%- ctx.post.contentUrl %>'>No plaintext embed support?</a>
+            </object>
+
 
         <% } else { %>
 

--- a/client/html/post_merge_side.tpl
+++ b/client/html/post_merge_side.tpl
@@ -47,6 +47,7 @@
                     'application/x-shockwave-flash': 'SWF',
                     'application/zip': 'ZIP',
                     'application/pdf': 'PDF',
+                    'text/plain': 'TXT',
                 }[ctx.post.mimeType] +
                 ' (' +
                 (ctx.post.canvasWidth ?

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -20,6 +20,7 @@
                     'application/x-shockwave-flash': 'SWF',
                     'application/zip': 'ZIP',
                     'application/pdf': 'PDF',
+                    'text/plain': 'TXT',
                 }[ctx.post.mimeType] %><!--
             --></a>
             (<%- ctx.post.canvasWidth %>x<%- ctx.post.canvasHeight %>)

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -23,6 +23,7 @@ function _mimeTypeToPostType(mimeType) {
             "image/heif": "image",
             "image/heic": "image",
             "image/vnd.adobe.photoshop": "image",
+            "text/plain": "txt",
             "video/mp4": "video",
             "video/webm": "video",
             "video/quicktime": "video",
@@ -126,6 +127,7 @@ class Url extends Uploadable {
             heif: "image/heif",
             heic: "image/heic",
             psd: "image/vnd.adobe.photoshop",
+            txt: "text/plain",
             mp4: "video/mp4",
             mov: "video/quicktime",
             webm: "video/webm",
@@ -171,7 +173,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd, .zip, .pdf",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd, .zip, .pdf, .txt",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -51,12 +51,19 @@ def get_mime_type(content: bytes) -> str:
     if content[0:4] == b"\x38\x42\x50\x53":
         return "image/vnd.adobe.photoshop"
 
+    try:
+        content.decode("utf-8")
+        return "text/plain"
+    except UnicodeDecodeError:
+        pass
+
     return "application/octet-stream"
 
 
 def get_extension(mime_type: str) -> Optional[str]:
     extension_map = {
         "application/pdf": "pdf",
+        "text/plain": "txt",
         "application/x-shockwave-flash": "swf",
         "application/zip": "zip",
         "image/gif": "gif",
@@ -122,11 +129,11 @@ def is_heif(mime_type: str) -> bool:
 def is_visual(mime_type: str) -> bool:
     return mime_type.lower() not in (
         "application/zip",
-        "application/pdf",
-    )
+    ) and not is_story(mime_type)
 
 
 def is_story(mime_type: str) -> bool:
     return mime_type.lower() in (
         "application/pdf",
+        "text/plain",
     )


### PR DESCRIPTION
This pull request adds support for uploading plaintext utf-8 files as .txt files.

They're supported as stories, and embedded like the pdf files