### PR TITLE
Support uploading TGS files

### DIFF
--- a/client/html/post_merge_side.tpl
+++ b/client/html/post_merge_side.tpl
@@ -46,6 +46,7 @@
                     'video/quicktime': 'MOV',
                     'application/x-shockwave-flash': 'SWF',
                     'application/zip': 'ZIP',
+                    'application/x-tgs': 'TGS',
                     'application/pdf': 'PDF',
                     'text/plain': 'TXT',
                 }[ctx.post.mimeType] +

--- a/client/html/post_readonly_sidebar.tpl
+++ b/client/html/post_readonly_sidebar.tpl
@@ -19,6 +19,7 @@
                     'video/quicktime': 'MOV',
                     'application/x-shockwave-flash': 'SWF',
                     'application/zip': 'ZIP',
+                    'application/x-tgs': 'TGS',
                     'application/pdf': 'PDF',
                     'text/plain': 'TXT',
                 }[ctx.post.mimeType] %><!--

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -13,6 +13,7 @@ function _mimeTypeToPostType(mimeType) {
         {
             "application/pdf": "pdf",
             "application/x-shockwave-flash": "flash",
+            "application/x-tgs": "zip",
             "application/zip": "zip",
             "image/gif": "image",
             "image/jpeg": "image",

--- a/client/js/views/post_upload_view.js
+++ b/client/js/views/post_upload_view.js
@@ -11,7 +11,7 @@ const rowTemplate = views.getTemplate("post-upload-row");
 function _mimeTypeToPostType(mimeType) {
     return (
         {
-            "application/pdf": "pdf",
+            "application/pdf": "story",
             "application/x-shockwave-flash": "flash",
             "application/x-tgs": "zip",
             "application/zip": "zip",
@@ -24,7 +24,7 @@ function _mimeTypeToPostType(mimeType) {
             "image/heif": "image",
             "image/heic": "image",
             "image/vnd.adobe.photoshop": "image",
-            "text/plain": "txt",
+            "text/plain": "story",
             "video/mp4": "video",
             "video/webm": "video",
             "video/quicktime": "video",
@@ -118,6 +118,7 @@ class Url extends Uploadable {
         let mime = {
             pdf: "application/pdf",
             swf: "application/x-shockwave-flash",
+            tgs: "application/x-tgs",
             zip: "application/zip",
             jpg: "image/jpeg",
             png: "image/png",
@@ -174,7 +175,7 @@ class PostUploadView extends events.EventTarget {
             this._contentInputNode,
             {
                 extraText:
-                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd, .zip, .pdf, .txt",
+                    "Allowed extensions: .jpg, .png, .gif, .webm, .mp4, .swf, .avif, .heif, .heic, .psd, .zip, .pdf, .txt, .tgs",
                 allowUrls: true,
                 allowMultiple: true,
                 lock: false,

--- a/server/szurubooru/func/mime.py
+++ b/server/szurubooru/func/mime.py
@@ -1,3 +1,5 @@
+import gzip
+import json
 import re
 from typing import Optional
 
@@ -57,7 +59,23 @@ def get_mime_type(content: bytes) -> str:
     except UnicodeDecodeError:
         pass
 
+    if _content_is_tgs_file(content):
+        return "application/x-tgs"
+
     return "application/octet-stream"
+
+
+def _content_is_tgs_file(content: bytes) -> bool:
+    try:
+        decompress = gzip.decompress(content)
+        data = json.loads(decompress)
+        if data.get("tgs") == 1:
+            return True
+        if isinstance(data.get("w"), int) and isinstance(data.get("h"), int):
+            return True
+        return False
+    except (gzip.BadGzipFile, json.JSONDecodeError):
+        return False
 
 
 def get_extension(mime_type: str) -> Optional[str]:
@@ -65,6 +83,7 @@ def get_extension(mime_type: str) -> Optional[str]:
         "application/pdf": "pdf",
         "text/plain": "txt",
         "application/x-shockwave-flash": "swf",
+        "application/x-tgs": "tgs",
         "application/zip": "zip",
         "image/gif": "gif",
         "image/jpeg": "jpg",
@@ -127,9 +146,14 @@ def is_heif(mime_type: str) -> bool:
 
 
 def is_visual(mime_type: str) -> bool:
-    return mime_type.lower() not in (
+    return not is_archive(mime_type) and not is_story(mime_type)
+
+
+def is_archive(mime_type: str) -> bool:
+    return mime_type.lower() in (
         "application/zip",
-    ) and not is_story(mime_type)
+        "application/x-tgs",
+    )
 
 
 def is_story(mime_type: str) -> bool:

--- a/server/szurubooru/func/posts.py
+++ b/server/szurubooru/func/posts.py
@@ -641,7 +641,7 @@ def update_post_content(post: model.Post, content: Optional[bytes]) -> None:
         post.type = model.Post.TYPE_VIDEO
     elif mime.is_story(post.mime_type):
         post.type = model.Post.TYPE_STORY
-    elif post.mime_type == "application/zip":
+    elif mime.is_archive(post.mime_type):
         post.type = model.Post.TYPE_ZIP
     else:
         raise InvalidPostContentError(


### PR DESCRIPTION
This isn't quite at the state I would like yet.

Currently the plan is supporting them as a type of archive, to bypass thumbnailing, image hashing, resolution detection, duration detection, etc.
Resolution and duration are quite easy to determine from a TGS file though, just unzip, and read the json. (resolution is the keys `h` and `w`. Duration is `(op - ip) * fr`). Trickier to convert to a PNG or whatever to do image hashing. Could skip that, dunno. Ideally, would use the pypi package, lottie: https://pypi.org/project/lottie

~~On the frontend, .. this is currently broken. It's attempting to use lottieplayer: https://www.npmjs.com/package/@lottiefiles/lottie-player direct from their CDN, which is not ideal. It's loading it up for every page, not ideal. And it's not working. Not certain why it's not working, it console logs something about failed file headers. Perhaps it can't take in the gzipped tgs file?
In the fullness of time, would be great to get that working. Though, would still display as a zip in the post listing. Unless I get the backend lottie stuff working for thumbnailing~~
Removed the frontend stuff, moving that to a separate PR
