### PR TITLE
An attempt at displaying tgs files in the frontend, using lottiefiles's tgs-player

### DIFF
--- a/client/html/index.htm
+++ b/client/html/index.htm
@@ -22,6 +22,7 @@
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-1668x2224.png' media='(min-device-width: 834px) and (max-device-width: 834px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='apple-touch-startup-image' href='img/apple-touch-startup-image-2048x2732.png' media='(min-device-width: 1024px) and (max-device-width: 1024px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: portrait)'/>
     <link rel='manifest' href='manifest.json'/>
+    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/tgs-player.js"></script>
 </head>
 <body>
     <div id='top-navigation-holder'></div>

--- a/client/html/post_content.tpl
+++ b/client/html/post_content.tpl
@@ -33,7 +33,12 @@
 
     <% } else if (ctx.post.type === 'zip') { %>
 
-        <% if (ctx.post.hasCustomThumbnail === true) { %>
+        <% if (ctx.post.mimeType === 'application/x-tgs') { %>
+
+            <tgs-player autoplay loop mode='normal' src='<%- ctx.post.contentUrl %>'>
+            </tgs-player>
+
+        <% } else if (ctx.post.hasCustomThumbnail === true) { %>
             
             <img class='resize-listener' alt='' src='<%- ctx.post.thumbnailUrl %>'/>
 


### PR DESCRIPTION
...but it seems to be unsuccessful

This got extracted from the PR adding support for TGS upload: https://github.com/Deer-Spangle/szurubooru/pull/7

> On the frontend, .. this is currently broken. It's attempting to use lottieplayer: https://www.npmjs.com/package/@lottiefiles/lottie-player direct from their CDN, which is not ideal. It's loading it up for every page, not ideal. And it's not working. Not certain why it's not working, it console logs something about failed file headers. Perhaps it can't take in the gzipped tgs file?
In the fullness of time, would be great to get that working. Though, would still display as a zip in the post listing. Unless I get the backend lottie stuff working for thumbnailing
Removed the frontend stuff, moving that to a separate PR